### PR TITLE
Highlighter Overflow

### DIFF
--- a/data/http-server-streaming.ts
+++ b/data/http-server-streaming.ts
@@ -15,7 +15,8 @@ import { serve } from "https://deno.land/std@0.114.0/http/server.ts";
 
 function handler(_req: Request): Response {
   // Set up a variable to store a timer ID, and the ReadableStream.
-  let timer: number | undefined = undefined;
+  let timer: number | undefined;
+
   const body = new ReadableStream({
     // When the stream is first created, start an interval that will emit a
     // chunk every second containing the current time.

--- a/www/pages/[id].tsx
+++ b/www/pages/[id].tsx
@@ -204,7 +204,7 @@ function SnippetComponent(props: {
         )}
         <div
           class={tw
-            `px-4 py-4 text-sm overflow-scroll sm:overflow-hidden relative` +
+            `px-4 py-4 text-sm overflow-scroll relative` +
             " highlight"}
         >
           <pre dangerouslySetInnerHTML={{ __html: renderedSnippet }} />

--- a/www/pages/[id].tsx
+++ b/www/pages/[id].tsx
@@ -203,8 +203,7 @@ function SnippetComponent(props: {
           </span>
         )}
         <div
-          class={tw
-            `px-4 py-4 text-sm overflow-scroll relative` +
+          class={tw`px-4 py-4 text-sm overflow-scroll relative` +
             " highlight"}
         >
           <pre dangerouslySetInnerHTML={{ __html: renderedSnippet }} />


### PR DESCRIPTION
- Remove unnecessary `sm:overflow-hidden` class from **highlighter** to fix `overflow` behavior on tablet and desktop screens.
- Remove unnecessary undefined assignation on `streaming` example.