### PR TITLE
fix: yaml stringify unneccessary args

### DIFF
--- a/data/parsing-serializing-yaml.ts
+++ b/data/parsing-serializing-yaml.ts
@@ -31,7 +31,7 @@ const obj = {
   hello: "world",
   numbers: [1, 2, 3],
 };
-const yaml = stringify(obj, null, 2);
+const yaml = stringify(obj);
 console.log(yaml);
 //- hello: word
 //- numbers:


### PR DESCRIPTION
I realized that I left this typo in while working on the toml example in #32. It still works (because javascript) but we should definitely not leave this in.