### PR TITLE
feat: benchmarking example

### DIFF
--- a/data/benchmarking.ts
+++ b/data/benchmarking.ts
@@ -2,7 +2,7 @@
  * @title Benchmarking
  * @difficulty beginner
  * @tags cli
- * @run deno bench --allow-net <url>
+ * @run deno bench <url>
  * @resource {https://deno.land/manual@v1.29.1/tools/benchmarker} Deno: Benchmarker tool
  * @resource {/http-requests} Example: HTTP Requests
  *
@@ -19,7 +19,7 @@ Deno.bench("URL parsing", () => {
 
 // We are also able to use an async function.
 Deno.bench("Async method", async () => {
-  await 1;
+  await crypto.subtle.digest("SHA-256", new Uint8Array([1, 2, 3]));
 });
 
 // We can optionally use long form bench definitions.

--- a/data/benchmarking.ts
+++ b/data/benchmarking.ts
@@ -1,0 +1,50 @@
+/**
+ * @title Benchmarking
+ * @difficulty beginner
+ * @tags cli
+ * @run deno bench --allow-net <url>
+ * @resource {https://deno.land/manual@v1.29.1/tools/benchmarker} Deno: Benchmarker tool
+ * @resource {/http-requests} Example: HTTP Requests
+ *
+ * When writing libraries, a very common task that needs to be done is
+ * testing the speed of methods, usually against other libraries. Deno
+ * provides an easy-to-use subcommand for this purpose.
+ */
+
+// The most basic form of deno benchmarking is providing a name and an
+// anonymous function to run.
+Deno.bench("URL parsing", () => {
+  new URL("https://deno.land");
+});
+
+// We are also able to use an async function.
+Deno.bench("Async method", async () => {
+  await 1;
+});
+
+// We can optionally use long form bench definitions.
+Deno.bench({
+  name: "Long form",
+  fn: () => {
+    new URL("https://deno.land");
+  },
+});
+
+// We are also able to group certain benchmarks together
+// using the optional group and baseline arguments.
+Deno.bench({
+  name: "Date.now()",
+  group: "timing",
+  baseline: true,
+  fn: () => {
+    Date.now();
+  },
+});
+
+Deno.bench({
+  name: "performance.now()",
+  group: "timing",
+  fn: () => {
+    performance.now();
+  },
+});

--- a/toc.js
+++ b/toc.js
@@ -3,6 +3,7 @@ export const TOC = [
   "color-logging",
   "import-export",
   "dependency-management",
+  "benchmarking",
   "importing-json",
   "parsing-serializing-json",
   "parsing-serializing-toml",

--- a/www/routes/[id].tsx
+++ b/www/routes/[id].tsx
@@ -143,7 +143,10 @@ export default function ExamplePage(props: PageProps<Data>) {
                   locally using the Deno CLI:
                 </p>
                 <pre class="mt-2 bg-gray-100 p-4 overflow-x-auto text-sm select-all rounded-md">
-                  deno run {example.run.replace("<url>", url)}
+                  {example.run.startsWith("deno")
+                    ?example.run.replace("<url>", url)
+                    :"deno run " + example.run.replace("<url>", url)
+                  }
                 </pre>
               </>
             )}


### PR DESCRIPTION
This PR also added the capability to change the subcommand (which is obviously necessary in the case of `deno bench`). 