### PR TITLE
fix: webassembly example

### DIFF
--- a/data/webassembly.ts
+++ b/data/webassembly.ts
@@ -1,7 +1,7 @@
 /**
  * @title Web Assembly
- * @difficulty beginner
- * @tags webassembly
+ * @difficulty intermediate
+ * @tags cli, deploy, web
  * @run <url>
  * @resource {https://webassembly.github.io/spec/core/syntax/modules.html} WebAssembly Spec: Modules
  * @resource {https://webassembly.github.io/spec/core/syntax/instructions.html} WebAssembly Spec: Instructions
@@ -12,22 +12,23 @@
  * It is a new and more efficient binary format.
  */
 
-// we create a new Uint8Array with the bytes of the WebAssembly module.
+// We create a new Uint8Array with the bytes of the WebAssembly module.
+// This is usually the output of some compiler and not written by hand.
 // deno-fmt-ignore
 const bytes = new Uint8Array([
-    0,97,115,109,1,0,0,0,1,7,1,96,2,
-    127,127,1,127,2,1,0,3,2,1,0,4,1,
-    0,5,1,0,6,1,0,7,7,1,3,97,100,100,
-    0,0,9,1,0,10,10,1,8,0,32,0,32,1,
-    106,15,11,11,1,0,
+  0,97,115,109,1,0,0,0,1,7,1,96,2,
+  127,127,1,127,2,1,0,3,2,1,0,4,1,
+  0,5,1,0,6,1,0,7,7,1,3,97,100,100,
+  0,0,9,1,0,10,10,1,8,0,32,0,32,1,
+  106,15,11,11,1,0,
 ]);
-// we create an interface for the WebAssembly module containing all exports.
+// We create an interface for the WebAssembly module containing all exports.
 interface WebAssemblyExports {
   add(a: number, b: number): number;
 }
 // The WebAssembly module is a binary format for describing a program's data and instructions.
 const exports = await WebAssembly.instantiate(bytes);
-// we get the exports from the WebAssembly module and cast it to the interface.
+// We get the exports from the WebAssembly module and cast it to the interface.
 const functions = exports.instance.exports as unknown as WebAssemblyExports;
-// we call the exported function.
+// We call the exported function.
 console.log(functions.add(1, 2)); // 3

--- a/toc.js
+++ b/toc.js
@@ -19,6 +19,7 @@ export const TOC = [
   "moving-renaming-files",
   "temporary-files",
   "create-remove-directories",
+  "webassembly",
   "http-requests",
   "uuids",
   "http-server",

--- a/www/utils/example.ts
+++ b/www/utils/example.ts
@@ -100,7 +100,6 @@ export function parseExample(id: string, file: string): Example {
         trimmedLine.startsWith("//deno-fmt-ignore")
       ) {
         // skip deno directives
-        console.log("skipped line", trimmedLine)
       } else if (trimmedLine.startsWith("//-")) {
         code += line.replace("//-", "//") + "\n";
       } else if (trimmedLine.startsWith("//")) {

--- a/www/utils/example.ts
+++ b/www/utils/example.ts
@@ -95,9 +95,12 @@ export function parseExample(id: string, file: string): Example {
         parseMode = "file";
       } else if (
         trimmedLine.startsWith("// deno-lint-ignore") ||
-        trimmedLine.startsWith("//deno-lint-ignore")
+        trimmedLine.startsWith("//deno-lint-ignore") ||
+        trimmedLine.startsWith("// deno-fmt-ignore") ||
+        trimmedLine.startsWith("//deno-fmt-ignore")
       ) {
-        // skip lint directives
+        // skip deno directives
+        console.log("skipped line", trimmedLine)
       } else if (trimmedLine.startsWith("//-")) {
         code += line.replace("//-", "//") + "\n";
       } else if (trimmedLine.startsWith("//")) {
@@ -114,9 +117,11 @@ export function parseExample(id: string, file: string): Example {
     } else if (parseMode == "comment") {
       if (
         trimmedLine.startsWith("// deno-lint-ignore") ||
-        trimmedLine.startsWith("//deno-lint-ignore")
+        trimmedLine.startsWith("//deno-lint-ignore") ||
+        trimmedLine.startsWith("// deno-fmt-ignore") ||
+        trimmedLine.startsWith("//deno-fmt-ignore")
       ) {
-        // skip lint directives
+        // skip deno directives
       } else if (trimmedLine.startsWith("//")) {
         text += " " + trimmedLine.slice(2).trim();
       } else {


### PR DESCRIPTION
The web assembly example is borked, this PR fixes it:
- Change the difficulty to intermediate, web assembly is definitely not beginner material. I would be more than okay making this advanced difficulty instead
- Changes the tag to the applicable list of tags, `webassembly` isn't an allowed tag atm
- Adds a comment to explain that web assembly is usually not written by hand
- Capitalizes comments to match rest of repo
- Adds `// deno-fmt-ignore` to ignored directives
- Adds `webassembly` to `toc.js`

The second and last issues are just symptoms of bad CI, I will make a separate PR to make sure this doesn't happen again. 