### PR TITLE
Turn footer logo into link

### DIFF
--- a/www/components/Footer.tsx
+++ b/www/components/Footer.tsx
@@ -12,10 +12,12 @@ const FOOTER_LINKS = [
 export function Footer() {
   return (
     <footer class="flex justify-between items-end p-8 pt-32">
-      <div class="flex align-center">
-        <DenoLogo />
-        <p class="ml-4 font-bold text-xl">Deno</p>
-      </div>
+      <a target="_blank" href="https://deno.land/">
+        <div class="flex align-center">
+          <DenoLogo />
+          <p class="ml-4 font-bold text-xl">Deno</p>
+        </div>
+      </a>
       <div class="flex flex-col lg:flex-row gap-x-8 gap-y-6 text-right">
         {FOOTER_LINKS.map(([href, text]) => (
           <a href={href} class="text-gray-500 hover:underline">{text}</a>


### PR DESCRIPTION
This allows people to click on the bottom logo + text, redirecting them to https://deno.land/ 