### PR TITLE
Clarify hashing example

### DIFF
--- a/data/hashing.ts
+++ b/data/hashing.ts
@@ -30,7 +30,6 @@ import { toHashString } from "$std/crypto/to_hash_string.ts";
 const hash = toHashString(hashBuffer);
 console.log(hash);
 
-
 // For our second example, we'll hash the contents of a file.
 // Hashing a file is a common operation and doing this
 // without loading the whole file into memory is a typical
@@ -56,4 +55,3 @@ const fileHashBuffer = await crypto.subtle.digest("SHA-256", readableStream);
 // Finally, we obtain the hex result using toHashString like earlier.
 const fileHash = toHashString(fileHashBuffer);
 console.log(fileHash);
-

--- a/data/hashing.ts
+++ b/data/hashing.ts
@@ -12,22 +12,14 @@
  * more advanced uses.
  */
 
-// The standard library has extensions to the Web
-// Crypto API that are useful when doing things
-// like hashing a file. These can be accessed through the
-// "crypto" module, a drop-in replacement for the Web Crypto
-// API that delegates to the native implementation when
-// possible.
-import { crypto } from "$std/crypto/mod.ts";
-
-// In our first example, we'll hash contents of a string variable.
+// In our first example, we'll hash the contents of a string variable.
 const message = "The easiest, most secure JavaScript runtime.";
 
-// Before we can pass our message to the crypto module,
+// Before we can pass our message to the hashing function,
 // we first need to encode it into a uint8 array.
 const messageBuffer = new TextEncoder().encode(message);
 
-// We use the crypto.subtle.digest method to hash our original message.
+// Here, we use the built-in crypto.subtle.digest method to hash our original message.
 // The hash is returned as an ArrayBuffer. To obtain a string
 // we'll need to do a little more work.
 const hashBuffer = await crypto.subtle.digest("SHA-256", messageBuffer);
@@ -43,12 +35,22 @@ console.log(hash);
 // Hashing a file is a common operation and doing this
 // without loading the whole file into memory is a typical
 // requirement.
+
+// The standard library has extensions to the Web
+// Crypto API that are useful when doing things
+// like hashing a file. These can be accessed through the
+// "crypto" module, a drop-in replacement for the Web Crypto
+// API that delegates to the native implementation when
+// possible.
+import { crypto } from "$std/crypto/mod.ts";
 const file = await Deno.open("example.txt", { read: true });
 
 // We obtain an async iterable using the readable property.
 const readableStream = file.readable;
 
-// We then use this as an async iterable and hash the file.
+// This time, when we call crypto.subtle.digest, we're using the
+// imported version that allows us to operate on the
+// async iterable.
 const fileHashBuffer = await crypto.subtle.digest("SHA-256", readableStream);
 
 // Finally, we obtain the hex result using toHashString like earlier.

--- a/data/hashing.ts
+++ b/data/hashing.ts
@@ -7,49 +7,51 @@
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest} MDN: Cryptographic Digests
  *
  * Hashing data is a common operation that is facilitated
- * through Deno's support of the Web Crypto API. There are
- * some more advanced uses that may require extensions to
- * the api that are provided by the standard library.
+ * through Deno's support for the Web Crypto API. In addition,
+ * Deno's implementation extends the standard API, allowing for
+ * more advanced uses.
  */
 
-// Our original plaintext message
+// The standard library has extensions to the Web
+// Crypto API that are useful when doing things
+// like hashing a file. These can be accessed through the
+// "crypto" module, a drop-in replacement for the Web Crypto
+// API that delegates to the native implementation when
+// possible.
+import { crypto } from "$std/crypto/mod.ts";
+
+// In our first example, we'll hash contents of a string variable.
 const message = "The easiest, most secure JavaScript runtime.";
 
-// We first need to encode it into a uint8 array since web
-// crypto only accepts them as arguments.
+// Before we can pass our message to the crypto module,
+// we first need to encode it into a uint8 array.
 const messageBuffer = new TextEncoder().encode(message);
 
-// We are now able to use the subtle crypto api to hash
-// our original message. Unfortunately, this is a buffer
-// so if we wanted to convert to a hex string we'd have
-// a little more work to do.
+// We use the crypto.subtle.digest method to hash our original message.
+// The hash is returned as an ArrayBuffer. To obtain a string
+// we'll need to do a little more work.
 const hashBuffer = await crypto.subtle.digest("SHA-256", messageBuffer);
 
 // We can decode this into a string using the standard
-// library's toHashString method
+// library's toHashString method.
 import { toHashString } from "$std/crypto/to_hash_string.ts";
 const hash = toHashString(hashBuffer);
 console.log(hash);
 
-// The standard library also has some useful extensions
-// to the Web Crypto API that is useful when doing something
-// like hashing a file. These can be accessed through the
-// drop "crypto" which is a drop in replacement for standard
-// Web Crypto which differs to the native implementation when
-// possible.
-import { crypto } from "$std/crypto/mod.ts";
 
-// Hashing a file is quite the common operation and doing this
-// without loading the whole file into memory is a common
+// For our second example, we'll hash the contents of a file.
+// Hashing a file is a common operation and doing this
+// without loading the whole file into memory is a typical
 // requirement.
 const file = await Deno.open("example.txt", { read: true });
 
-// We can obtain an async iterable using the readable property
+// We obtain an async iterable using the readable property.
 const readableStream = file.readable;
 
-// We can then use this as an async iterable and hash the file
+// We then use this as an async iterable and hash the file.
 const fileHashBuffer = await crypto.subtle.digest("SHA-256", readableStream);
 
-// We can then obtain the hex result using toHashString like earlier
+// Finally, we obtain the hex result using toHashString like earlier.
 const fileHash = toHashString(fileHashBuffer);
 console.log(fileHash);
+

--- a/data/hashing.ts
+++ b/data/hashing.ts
@@ -8,7 +8,7 @@
  *
  * Hashing data is a common operation that is facilitated
  * through Deno's support for the Web Crypto API. In addition,
- * Deno's implementation extends the standard API, allowing for
+ * the Deno standard library's implementation extends the standard API, allowing for
  * more advanced uses.
  */
 


### PR DESCRIPTION
This PR makes two changes:
* Make it clear that the example addresses two different use cases (hashing a variable vs hashing a file's contents)
* ~~Move the `import {crypto}` to the top of the example so that it appears before the first `crypto.subtle.digest` call~~ Inform the reader that the first example uses the built-in Web Crypto functionality and the second example relies on enhanced functionality from the import.
