### PR TITLE
fix: stop disabling user selection of snippet text

### DIFF
--- a/www/routes/[id]/index.tsx
+++ b/www/routes/[id]/index.tsx
@@ -247,7 +247,7 @@ function SnippetComponent(props: {
 
   return (
     <div class="grid grid-cols-1 sm:grid-cols-5 gap-x-6  transition duration-150 ease-in">
-      <div class="py-4 text-gray-700 select-none col-span-2">
+      <div class="py-4 text-gray-700 col-span-2">
         {props.snippet.text}
       </div>
       <div


### PR DESCRIPTION
Not being able to select text is annoying.