### PR TITLE
chore: fix typo in "Subprocesses: Spawning"

### DIFF
--- a/data/subprocesses-spawn.ts
+++ b/data/subprocesses-spawn.ts
@@ -22,7 +22,7 @@ const command = new Deno.Command("deno", {
   stdout: "piped",
 });
 
-// In the a slightly more complex case, we want to interact with a spawned
+// In a slightly more complex case, we want to interact with a spawned
 // process. To do this, we first need to spawn it.
 const process = await command.spawn();
 


### PR DESCRIPTION
Hi, I found and fixed typo in "Subprocesses: Spawning".

https://examples.deno.land/subprocesses-spawn
