### PR TITLE
New examples for upcoming homepage work, increase code sample width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+deno.lock

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ of the APIs implemented in Deno.
 - Examples are written in TypeScript
 - Each example should be a single file, no more than 50 lines
 - Each example should be a self-contained unit, and should depend on no
-  dependencies other than Deno builtins and the standard library (exceptions can
-  be made)
+  dependencies other than Deno builtins and the standard library, unless a
+  third-party library is strictly required.
 - Each example should be runnable without additional dependencies on all systems
   (exceptions can be made for platform specific functionality)
 - Examples should be introduce at most one (or in exceptional cases two or

--- a/data/kv.ts
+++ b/data/kv.ts
@@ -1,0 +1,83 @@
+/**
+ * @title Deno KV: Key/Value Database
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run --unstable <url>
+ * @resource {https://deno.land/manual/runtime/kv} Deno KV user guide
+ * @resource {https://deno.land/api?unstable=&s=Deno.Kv} Deno KV Runtime API docs
+ *
+ * Deno KV is a key/value database built in to the Deno runtime, and works with
+ * zero configuration on Deno Deploy. It's great for use cases that require fast
+ * reads and don't require the query flexibility of a SQL database.
+ */
+
+// Open the default database
+const kv = await Deno.openKv();
+
+// Define an interface in TypeScript for our data
+enum Rank {
+  Bronze,
+  Silver,
+  Gold,
+}
+
+interface Player {
+  username: string;
+  rank: Rank;
+}
+
+// Create a few instances for testing
+const player1: Player = { username: "carlos", rank: Rank.Bronze };
+const player2: Player = { username: "briana", rank: Rank.Silver };
+const player3: Player = { username: "alice", rank: Rank.Bronze };
+
+// Store object data in Deno KV using the "set" operation. Keys can be arranged
+// hierarchically, not unlike resources in a REST API.
+await kv.set(["players", player1.username], player1);
+await kv.set(["players", player2.username], player2);
+await kv.set(["players", player3.username], player3);
+
+// The "set" operation is used to both create and update data for a given key
+player3.rank = Rank.Gold;
+await kv.set(["players", player3.username], player3);
+
+// Fetch a single object by key with the "get" operation
+const record = await kv.get(["players", "alice"]);
+const alice: Player = record.value as Player;
+console.log(record.key, record.versionstamp, alice);
+
+// Fetch several objects by key with "getMany"
+const [record1, record2] = await kv.getMany([
+  ["players", "carlos"],
+  ["players", "briana"],
+]);
+console.log(record1, record2);
+
+// List several records by key prefix - note that results are ordered
+// lexicographically, so our players will be fetched in the order
+// "alice", "briana", "carlos"
+const records = await kv.list({ prefix: ["players"] });
+const players = [];
+for await (const res of records) {
+  players.push(res.value as Player);
+}
+console.log(players);
+
+// Delete a value for a given key
+await kv.delete(["players", "carlos"]);
+
+// The Deno.KvU64 object is a wrapper for 64 bit integers (BigInt), so you can
+// quickly update very large numbers. Let's add a "score" for alice.
+const aliceScoreKey = ["scores", "alice"];
+await kv.set(aliceScoreKey, new Deno.KvU64(0n));
+
+// Add 10 to the player's score in an atomic transaction
+await kv.atomic()
+  .mutate({
+    type: "sum",
+    key: aliceScoreKey,
+    value: new Deno.KvU64(10n),
+  })
+  .commit();
+const newScore = (await kv.get(aliceScoreKey)).value as Deno.KvU64;
+console.log("Alice's new score is: ", newScore);

--- a/data/kv.ts
+++ b/data/kv.ts
@@ -79,5 +79,5 @@ await kv.atomic()
     value: new Deno.KvU64(10n),
   })
   .commit();
-const newScore = (await kv.get(aliceScoreKey)).value as Deno.KvU64;
+const newScore = (await kv.get<Deno.KvU64>(aliceScoreKey)).value;
 console.log("Alice's new score is: ", newScore);

--- a/data/node.ts
+++ b/data/node.ts
@@ -1,0 +1,18 @@
+/**
+ * @title Use Node.js built-in modules
+ * @difficulty beginner
+ * @tags cli, deploy
+ * @run --allow-env <url>
+ * @resource {https://deno.land/manual/node} Node.js / npm support in Deno
+ * @resource {https://deno.land/manual/node/node_specifiers} node: specifiers
+ *
+ * Deno supports most built-in Node.js modules natively - you can include them
+ * in your code using "node:" specifiers in your imports.
+ */
+
+// Import the os module from core Node to get operating system info
+import os from "node:os";
+
+// Use the module as you would in Node.js
+console.log("Current architecture is:", os.arch());
+console.log("Home directory is:", os.homedir());

--- a/data/npm.ts
+++ b/data/npm.ts
@@ -7,7 +7,7 @@
  * @resource {https://deno.land/manual/node/npm_specifiers} npm: specifiers
  * @resource {https://www.npmjs.com/package/express} express module on npm
  *
- * Use JavaScript modules from npm in your Deno programs with the "npm:" 
+ * Use JavaScript modules from npm in your Deno programs with the "npm:"
  * specifier in your imports.
  */
 

--- a/data/npm.ts
+++ b/data/npm.ts
@@ -1,0 +1,28 @@
+/**
+ * @title Import modules from npm
+ * @difficulty beginner
+ * @tags cli
+ * @run --allow-net --allow-read --allow-env <url>
+ * @resource {https://deno.land/manual/node} Node.js / npm support in Deno
+ * @resource {https://deno.land/manual/node/npm_specifiers} npm: specifiers
+ * @resource {https://www.npmjs.com/package/express} express module on npm
+ *
+ * Use JavaScript modules from npm in your Deno programs with the "npm:" 
+ * specifier in your imports.
+ */
+
+// Import the express module from npm using an npm: prefix, and appending a
+// version number. Dependencies from npm can be configured in an import map
+// also.
+import express from "npm:express@4.18.2";
+
+// Create an express server
+const app = express();
+
+// Configure a route that will process HTTP GET requests
+app.get("/", (_req, res) => {
+  res.send("Welcome to the Dinosaur API!");
+});
+
+// Start an HTTP server using the configured Express app
+app.listen(3000);

--- a/data/piping-streams.ts
+++ b/data/piping-streams.ts
@@ -1,0 +1,52 @@
+/**
+ * @title Piping Streams
+ * @difficulty intermediate
+ * @tags cli
+ * @run --allow-net --allow-read --allow-write <url>
+ * @resource {https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream} MDN: ReadableStream
+ * @resource {/tcp-listener.ts} Example: TCP Listener
+ *
+ * Deno implements web-standard streams which comes with many advantages. One of the most useful
+ * features of streams is how they can be piped to and from different sources.
+ */
+
+// A common usecase for streams is downloading files without buffering the whole file in memory.
+// First, we open a file we want to write to
+const download = await Deno.open("example.html", { create: true, write: true });
+
+// Now let's make a request to a web page
+const req = await fetch("https://examples.deno.land");
+
+// We can pipe this response straight into the file. In a more realistic example, we would
+// handle a bad request, but here we'll just use the nullish coalescing operator. Instead of
+// opening the file and manually piping the fetch body to it, we could also just use `Deno.writeFile`.
+req.body?.pipeTo(download.writable);
+
+// Pipes can connect a lot of things. For example, we could pipe the file we just downloaded into
+// stdout. We could also pipe our streams through transformers to get a more interesting result. In this
+// case, we will pipe our file through a stream which will highlight all "<" characters in the terminal.
+
+// First we will import a utility from the standard library to help us with this.
+import { bgBrightYellow } from "$std/fmt/colors.ts";
+
+// Then we will create a transform stream utility class
+class HighlightTransformStream extends TransformStream<string, string> {
+  constructor() {
+    super({
+      transform: (chunk, controller) => {
+        controller.enqueue(chunk.replaceAll("<", bgBrightYellow("<")));
+      },
+    });
+  }
+}
+
+// Let's open our file for reading
+const example = await Deno.open("example.html", { read: true });
+
+// Now we can pipe the result from the file, into a TextDecoderStream, into our custom transform class,
+// back through a TextEncoderStream, and finally into stdout
+await example.readable
+  .pipeThrough(new TextDecoderStream())
+  .pipeThrough(new HighlightTransformStream())
+  .pipeThrough(new TextEncoderStream())
+  .pipeTo(Deno.stdout.writable);

--- a/data/postgres.ts
+++ b/data/postgres.ts
@@ -1,0 +1,31 @@
+/**
+ * @title Connect to Postgres
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run --allow-net --allow-env <url>
+ * @resource {https://deno-postgres.com/} Deno Postgres docs
+ * @resource {https://deno.land/x/postgres} Deno Postgres on deno.land/x
+ *
+ * Using the Deno Postgres client, you can connect to a Postgres database
+ * running anywhere.
+ */
+
+// Import the Client constructor from deno.land/x
+import { Client } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
+
+// Initialize the client with connection information for your database, and
+// create a connection.
+const client = new Client({
+  user: "user",
+  database: "test",
+  hostname: "localhost",
+  port: 5432,
+});
+await client.connect();
+
+// Execute a SQL query
+const result = await client.queryArray("SELECT ID, NAME FROM PEOPLE");
+console.log(result.rows); // [[1, 'Carlos'], [2, 'John'], ...]
+
+// Close the connection to the database
+await client.end();

--- a/data/tls-connector.ts
+++ b/data/tls-connector.ts
@@ -1,0 +1,28 @@
+/**
+ * @title TCP/TLS Connector: Ping
+ * @difficulty intermediate
+ * @tags cli
+ * @run --allow-net --allow-read <url>
+ * @resource {https://deno.land/api?s=Deno.connectTls} Doc: Deno.connectTls
+ * @resource {/tls-listener.ts} Example: TCP/TLS Listener
+ *
+ * An example of connecting to a TCP server using TLS on localhost and writing a 'ping' message to the server.
+ */
+
+// Read a CA Certificate from the file system
+const caCert = await Deno.readTextFile("./root.pem");
+
+// Establish a connection to our TCP server using TLS that is currently being run on localhost port 443.
+// We use a custom CA root certificate here. If we remove this option, Deno defaults to using
+// Mozilla's root certificates.
+const conn = await Deno.connectTls({
+  hostname: "127.0.0.1",
+  port: 443,
+  caCerts: [caCert],
+});
+
+// Instantiate an instance of text encoder to write to the TCP stream.
+const encoder = new TextEncoder();
+
+// Encode the 'ping' message and write to the TCP connection for the server to receive.
+await conn.write(encoder.encode("ping"));

--- a/data/tls-listener.ts
+++ b/data/tls-listener.ts
@@ -1,0 +1,27 @@
+/**
+ * @title TCP/TLS Listener: Ping
+ * @difficulty intermediate
+ * @tags cli
+ * @run --allow-net --allow-read <url>
+ * @resource {https://deno.land/api?s=Deno.listenTls} Doc: Deno.listenTls
+ *
+ * An example of a TCP listener using TLS on localhost that will log the message if written to and close the connection if connected to.
+ */
+
+// Instantiate an instance of a TCP listener on localhost port 443.
+const listener = Deno.listenTls({
+  hostname: "127.0.0.1",
+  port: 443,
+  transport: "tcp",
+  cert: Deno.readTextFileSync("./server.crt"),
+  key: Deno.readTextFileSync("./server.key"),
+});
+
+// Await asynchronous connections that are established to our TCP listener.
+for await (const conn of listener) {
+  // Pipe the contents of the TCP stream into stdout
+  await conn.readable.pipeTo(Deno.stdout.writable);
+
+  // We close the connection that was established.
+  conn.close();
+}

--- a/data/typescript.ts
+++ b/data/typescript.ts
@@ -5,7 +5,7 @@
  * @run <url>
  * @resource {https://www.typescriptlang.org/docs/handbook/intro.html} TypeScript handbook
  *
- * Deno natively understands TypeScript code with no compiler to configure. 
+ * Deno natively understands TypeScript code with no compiler to configure.
  * Start writing code in .ts files, and the runtime will work with them just
  * fine.
  */
@@ -15,7 +15,7 @@ interface Person {
   name: string;
   age: number;
 }
- 
+
 // Provide a typed input to a function
 function greet(person: Person) {
   return "Hello, " + person.name + "!";

--- a/data/typescript.ts
+++ b/data/typescript.ts
@@ -1,0 +1,25 @@
+/**
+ * @title Built-in TypeScript support
+ * @difficulty beginner
+ * @tags cli, deploy
+ * @run <url>
+ * @resource {https://www.typescriptlang.org/docs/handbook/intro.html} TypeScript handbook
+ *
+ * Deno natively understands TypeScript code with no compiler to configure. 
+ * Start writing code in .ts files, and the runtime will work with them just
+ * fine.
+ */
+
+// Define an interface in TypeScript
+interface Person {
+  name: string;
+  age: number;
+}
+ 
+// Provide a typed input to a function
+function greet(person: Person) {
+  return "Hello, " + person.name + "!";
+}
+
+// Everything works with zero config!
+console.log(greet({ name: "Alice", age: 36 }));

--- a/toc.ts
+++ b/toc.ts
@@ -1,3 +1,4 @@
+import IconDatabase from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/database.tsx";
 import IconFlag3 from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/flag-3.tsx";
 import IconTransform from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/transform.tsx";
 import IconFileShredder from "https://deno.land/x/tabler_icons_tsx@0.0.3/tsx/file-shredder.tsx";
@@ -23,6 +24,9 @@ export const TOC: TocGroup[] = [
       "color-logging",
       "import-export",
       "dependency-management",
+      "node",
+      "npm",
+      "typescript",
       "timers",
       "url-parsing",
     ],
@@ -98,7 +102,14 @@ export const TOC: TocGroup[] = [
       "streaming-files",
     ],
   },
-
+  {
+    title: "Databases",
+    icon: IconDatabase,
+    items: [
+      "postgres",
+      "kv",
+    ],
+  },
   {
     title: "Cryptography",
     icon: IconFileShredder,

--- a/toc.ts
+++ b/toc.ts
@@ -70,6 +70,7 @@ export const TOC: TocGroup[] = [
       "http-server-websocket",
       "tcp-listener",
       "tcp-connector",
+      "piping-streams",
     ],
   },
   {

--- a/toc.ts
+++ b/toc.ts
@@ -70,6 +70,8 @@ export const TOC: TocGroup[] = [
       "http-server-websocket",
       "tcp-listener",
       "tcp-connector",
+      "tls-listener",
+      "tls-connector",
       "piping-streams",
     ],
   },

--- a/www/routes/[id]/index.tsx
+++ b/www/routes/[id]/index.tsx
@@ -143,9 +143,9 @@ export default function ExamplePage(props: PageProps<Data>) {
             ))}
           </div>
         ))}
-        <div class="grid grid-cols-1 sm:grid-cols-5 gap-x-6">
-          <div class="col-span-2 mt-8" />
-          <div class="col-span-3 mt-8">
+        <div class="grid grid-cols-1 sm:grid-cols-10 gap-x-8">
+          <div class="col-span-3 mt-8" />
+          <div class="col-span-7 mt-8">
             {example.run && (
               <>
                 <p class="text-gray-700">
@@ -246,12 +246,12 @@ function SnippetComponent(props: {
   );
 
   return (
-    <div class="grid grid-cols-1 sm:grid-cols-5 gap-x-6  transition duration-150 ease-in">
-      <div class="py-4 text-gray-700 select-none col-span-2">
+    <div class="grid grid-cols-1 sm:grid-cols-10 gap-x-8  transition duration-150 ease-in">
+      <div class="py-4 text-gray-700 select-none col-span-3 text-sm">
         {props.snippet.text}
       </div>
       <div
-        class={`col-span-3 relative bg-gray-100 ${
+        class={`col-span-7 relative bg-gray-100 ${
           props.firstOfFile ? "rounded-t-md" : ""
         } ${props.lastOfFile ? "rounded-b-md" : ""} ${
           props.snippet.code.length === 0 ? "hidden sm:block" : ""


### PR DESCRIPTION
This change contains new samples that will be linked from an upcoming iteration of the deno.land homepage. It also contains some minor changes to the utility classes used on the code sample pages to enable them to display 80 columns without obscuring the last ~10 characters of longer lines.