### PR TITLE
Correct the URL of the assert package in the Writing Tests example

### DIFF
--- a/data/writing-tests.ts
+++ b/data/writing-tests.ts
@@ -12,7 +12,7 @@
 
 // First, we import assert statements from the standard library. There are
 // quite a few options but we will just import the most common ones here.
-import { assert, assertEquals } from "$std/asserts/mod.ts";
+import { assert, assertEquals } from "$std/assert/mod.ts";
 
 // The most simple way to use the test runner is to just pass it a description
 // and a callback function


### PR DESCRIPTION
### Related Issues
- Resolves #103 

### What Was Accomplished
- Updated the Writing Tests example to correct the URL of the `assert` package.

### How To Test
- The CLI command from the Writing Tests example page that was reported to be broken in the issue is working in the deploy preview.