### PR TITLE
fix: Writing Tests assert module name

### DIFF
--- a/data/writing-tests.ts
+++ b/data/writing-tests.ts
@@ -4,7 +4,7 @@
  * @tags cli
  * @run deno test --allow-read --allow-write <url>
  * @resource {https://deno.land/api?s=Deno.test} Doc: Deno.test
- * @resource {$std/testing/asserts.ts} Doc: std/testing/asserts
+ * @resource {$std/testing/assert.ts} Doc: std/testing/assert
  *
  * One of the most common tasks in developing software is writing tests for
  * existing code. Deno has a built-in test runner which makes this very easy.
@@ -12,7 +12,7 @@
 
 // First, we import assert statements from the standard library. There are
 // quite a few options but we will just import the most common ones here.
-import { assert, assertEquals } from "$std/asserts/mod.ts";
+import { assert, assertEquals } from "$std/assert/mod.ts";
 
 // The most simple way to use the test runner is to just pass it a description
 // and a callback function


### PR DESCRIPTION
It appears to have changed from `asserts` to `assert`, https://deno.land/std@0.202.0/assert/mod.ts works whereas the previous URL 404s