### PR TITLE
Fix missing negation in CLI arguments example

### DIFF
--- a/data/command-line-arguments.ts
+++ b/data/command-line-arguments.ts
@@ -26,6 +26,7 @@ const flags = parse(Deno.args, {
   boolean: ["help", "color"],
   string: ["version"],
   default: { color: true },
+  negatable: ["color"],
 });
 console.log("Wants help?", flags.help);
 console.log("Version:", flags.version);


### PR DESCRIPTION
The suggested CLI example includes a negation (`--no-color`) that is not supported by the code, thus returning a confusing response.