### PR TITLE
Fix command-line-arguments for changing std/flags to new std/cli sub-module 

### DIFF
--- a/data/command-line-arguments.ts
+++ b/data/command-line-arguments.ts
@@ -4,7 +4,7 @@
  * @tags cli
  * @run <url> Deno Sushi --help --version=1.0.0 --no-color
  * @resource {https://deno.land/api?s=Deno.args} Doc: Deno.args
- * @resource {$std/flags/mod.ts} Doc: std/flags
+ * @resource {$std/cli/parse_args.ts} Doc: std/cli
  *
  * Command line arguments are often used to pass configuration options to a
  * program.
@@ -16,13 +16,13 @@ const food = Deno.args[1];
 console.log(`Hello ${name}, I like ${food}!`);
 
 // Often you want to parse command line arguments like `--foo=bar` into
-// structured data. This can be done using `std/flags`.
-import { parse } from "$std/flags/mod.ts";
+// structured data. This can be done using `std/cli`.
+import { parseArgs } from "$std/cli/parse_args.ts";
 
-// The `parse` function takes the argument list, and a list of options. In these
+// The `parseArgs` function takes the argument list, and a list of options. In these
 // options you specify the types of the accepted arguments and possibly default
 // values. An object is returned with the parsed arguments.
-const flags = parse(Deno.args, {
+const flags = parseArgs(Deno.args, {
   boolean: ["help", "color"],
   string: ["version"],
   default: { color: true },

--- a/data/command-line-arguments.ts
+++ b/data/command-line-arguments.ts
@@ -22,6 +22,7 @@ import { parseArgs } from "$std/cli/parse_args.ts";
 // The `parseArgs` function takes the argument list, and a list of options. In these
 // options you specify the types of the accepted arguments and possibly default
 // values. An object is returned with the parsed arguments.
+// NOTE: this function is based on [`minimist`](https://github.com/minimistjs/minimist), not compatible with the `parseArgs()` function in `node:util`.
 const flags = parseArgs(Deno.args, {
   boolean: ["help", "color"],
   string: ["version"],


### PR DESCRIPTION
In https://github.com/denoland/deno_std/pull/3530, `parse()` in std/flags was moved to `parseArgs()` in std/cli sub module.
