### PR TITLE
Uses Uint8Array instead of Int8Array as base64.encode does not support Int8Array

### DIFF
--- a/data/hex-base64-encoding.ts
+++ b/data/hex-base64-encoding.ts
@@ -15,7 +15,7 @@ import * as hex from "$std/encoding/hex.ts";
 
 // We can easily encode a string or an array buffer into base64 using the base64.encode method.
 const base64Encoded = base64.encode("somestringtoencode");
-console.log(base64.encode(new Int8Array([1, 32, 67, 120, 19])));
+console.log(base64.encode(new Uint8Array([1, 32, 67, 120, 19])));
 
 // We can then decode base64 into a byte array using the decode method.
 const base64Decoded = base64.decode(base64Encoded);


### PR DESCRIPTION
With deno --version

deno 1.40.2 (release, x86_64-apple-darwin)
v8 12.1.285.6
typescript 5.3.3

Using Int8Array as a argument for base64.encode result in below error:

```
error: Uncaught (in promise) TypeError: The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type Int8Array.
  throw new TypeError(
        ^
    at validateBinaryLike (https://deno.land/std@0.207.0/encoding/_util.ts:24:9)
    at Module.encodeBase64 (https://deno.land/std@0.207.0/encoding/base64.ts:121:17)
```