### PR TITLE
Use Twind v1

### DIFF
--- a/fresh.config.ts
+++ b/fresh.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "$fresh/server.ts";
-import twindPlugin from "$fresh/plugins/twind.ts";
+import twindPlugin from "$fresh/plugins/twindv1.ts";
 import twindConfig from "./twind.config.ts";
 export default defineConfig({
   plugins: [twindPlugin(twindConfig)],

--- a/twind.config.ts
+++ b/twind.config.ts
@@ -1,5 +1,10 @@
-import { Options } from "$fresh/plugins/twind.ts";
+import { defineConfig, Preset } from "https://esm.sh/@twind/core@1.1.3";
+import presetTailwind from "https://esm.sh/@twind/preset-tailwind@1.1.4";
+import presetAutoprefix from "https://esm.sh/@twind/preset-autoprefix@1.0.7";
 
 export default {
+  ...defineConfig({
+    presets: [presetTailwind() as Preset, presetAutoprefix()],
+  }),
   selfURL: import.meta.url,
-} as Options;
+};

--- a/twind.config.ts
+++ b/twind.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, Preset } from "https://esm.sh/@twind/core@1.1.3";
-import presetTailwind from "https://esm.sh/@twind/preset-tailwind@1.1.4";
-import presetAutoprefix from "https://esm.sh/@twind/preset-autoprefix@1.0.7";
+import { defineConfig, Preset } from "@twind/core";
+import presetTailwind from "@twind/preset-tailwind";
+import presetAutoprefix from "@twind/preset-autoprefix";
 
 export default {
   ...defineConfig({


### PR DESCRIPTION
The story is that I was trying to add some dark mode support to _Deno by Example_. However it seems that the `dark:` variants ([according to Twind documentation](https://twind.dev/handbook/configuration.html#dark-mode)) isn't working, although the attribute did show up in the resulting HTML.

Luckily I noticed the title ["Using Twind v1"](https://fresh.deno.dev/docs/examples/using-twind-v1) in Fresh docs. After applying instructions said there, the `dark:` attributes is working as expected.
